### PR TITLE
fix: Extra tilda causes fatal error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The whole flow for deal making (from file upload to making a deal on FVM) is des
 Get started by typing in the following commands into your terminal/command prompt. This will clone the repo and all submodules, switch into the hardhat kit, and install packages: 
 
 ```
-git clone https://github.com/filecoin-project/fvm-starter-kit-deal-making.git~
+git clone https://github.com/filecoin-project/fvm-starter-kit-deal-making.git
 cd fvm-starter-kit-deal-making
 yarn install
 ```


### PR DESCRIPTION
The extra tilda at the end of the git clone command causes a fatal error when trying to clone the repo:
```
Cloning into 'fvm-starter-kit-deal-making.git~'...
remote: Repository not found.
fatal: repository 'https://github.com/filecoin-project/fvm-starter-kit-deal-making.git~/' not found
cd: no such file or directory: fvm-starter-kit-deal-making
```

Simply removing the tilda resolves the problem:
```
Cloning into 'fvm-starter-kit-deal-making'...
remote: Enumerating objects: 253, done.
remote: Counting objects: 100% (60/60), done.
remote: Compressing objects: 100% (37/37), done.
remote: Total 253 (delta 33), reused 25 (delta 22), pack-reused 193
Receiving objects: 100% (253/253), 1.12 MiB | 2.82 MiB/s, done.
Resolving deltas: 100% (109/109), done.
```